### PR TITLE
Add typings in package.json for better typescript support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.5",
   "description": "Facebook TypeScript SDK for Angular2",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This is needed because everything in the project is put in the `dist` folder. Otherwise I had to import like this
```
import { FacebookService } from 'ng2-facebook-sdk/dist'
```
With the change, I can do
```
import { FacebookService } from 'ng2-facebook-sdk'
```

For why, read https://www.typescriptlang.org/docs/handbook/module-resolution.html
11. /root/node_modules/moduleB/package.json (if it specifies a "typings" property)