### PR TITLE
Exports for Ionic2 rc1 support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,10 @@
-export * from './ng2-facebook-sdk';
+export {
+  FacebookService,
+  FacebookInitParams,
+  FacebookApiMethod,
+  FacebookUiParams,
+  FacebookAuthResponse,
+  FacebookLoginStatus,
+  FacebookLoginOptions,
+  FacebookLoginResponse
+} from './ng2-facebook-sdk';


### PR DESCRIPTION
Hi,

For this package to work on Ionc2 rc0+ without the need to add it on rollup.config.ts we need to avoid using `export * from`.
Instead we need to manually re-export each one on the index.ts.

I've tested it and with this fix it works like a charm :)