### PR TITLE
Adding `message` parameter to `FacebookUiParams`

### DIFF
--- a/src/ng2-facebook-sdk.ts
+++ b/src/ng2-facebook-sdk.ts
@@ -311,6 +311,11 @@ export interface FacebookUiParams extends ShareDialogParams, FeedDialogParams, S
   method: any;
 
   /**
+   * The UI dialog message.
+   */
+  message?: string;
+
+  /**
    * Your app's unique identifier. Required.
    */
   app_id?: string;


### PR DESCRIPTION
Addressing zyramedia/ng2-facebook-sdk#57
Used in game requests (`apprequests` ui method)
https://developers.facebook.com/docs/games/services/gamerequests#jssdk