### PR TITLE
Addressing #57 in v2

### DIFF
--- a/src/models/ui-params.ts
+++ b/src/models/ui-params.ts
@@ -99,6 +99,11 @@ export interface UIParams extends ShareDialogParams, FeedDialogParams, SendDialo
     method: any;
 
     /**
+     * The UI dialog message.
+     */
+    message?: string;
+
+    /**
      * Your app's unique identifier. Required.
      */
     app_id?: string;


### PR DESCRIPTION
This is the same update for v2...

Addressing zyramedia/ng2-facebook-sdk#57
Used in game requests (`apprequests` ui method)
https://developers.facebook.com/docs/games/services/gamerequests#jssdk